### PR TITLE
Compiles with Ros Kinetic on Ubuntu 16.04

### DIFF
--- a/tld_tracker/CMakeLists.txt
+++ b/tld_tracker/CMakeLists.txt
@@ -25,7 +25,7 @@ include(ExternalProject)
 
 externalproject_add(opentld
   PREFIX libopentld
-  SVN_REPOSITORY  https://github.com/Ronan0912/OpenTLD/trunk/
+  SVN_REPOSITORY  https://github.com/GabrielAlacchi/OpenTLD/trunk
   SVN_REVISION    -rHEAD
   PATCH_COMMAND   patch -p0 -i ${PROJECT_SOURCE_DIR}/opentld/patches/diff1.patch
                   &&


### PR DESCRIPTION
I essentially point the CMakeLists.txt to compile with my own fork of opentld which is based off of the fork from Ronan0912. I fixed the opencv API differences in that source code and this driver now compiles. I'm not sure how to go about testing it since I've never used this before but the changes I made are hardly groundbreaking so I doubt it wouldn't work like it used to.